### PR TITLE
Add tile animations

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,9 @@ let gameState = {
     crystals: 3,
     gravity: 'south', // north, east, south, west
     moveHistory: [],
-    gameActive: false
+    gameActive: false,
+    nextId: 1,
+    lastAdded: null
 };
 
 // Game configuration
@@ -64,7 +66,7 @@ function getMaxTile(board) {
     let max = 0;
     for (let r = 0; r < BOARD_SIZE; r++) {
         for (let c = 0; c < BOARD_SIZE; c++) {
-            if (board[r][c] > max) max = board[r][c];
+            if (board[r][c].value > max) max = board[r][c].value;
         }
     }
     return max;
@@ -89,6 +91,10 @@ const ACHIEVEMENTS = [
     {tile: 512, crystals_reward: 3}
 ];
 
+function createTile(value = 0) {
+    return { id: value === 0 ? null : gameState.nextId++, value };
+}
+
 // Initialize game
 function initGame() {
     // Load best score from localStorage if available
@@ -99,7 +105,11 @@ function initGame() {
     }
     
     // Initialize empty board
-    gameState.board = Array(BOARD_SIZE).fill().map(() => Array(BOARD_SIZE).fill(0));
+    gameState.board = Array.from({ length: BOARD_SIZE }, () => (
+        Array.from({ length: BOARD_SIZE }, () => createTile())
+    ));
+    gameState.nextId = 1;
+    gameState.lastAdded = null;
     gameState.score = 0;
     gameState.crystals = 3;
     gameState.gravity = 'south';
@@ -144,7 +154,7 @@ function addRandomTile() {
     const emptyCells = [];
     for (let r = 0; r < BOARD_SIZE; r++) {
         for (let c = 0; c < BOARD_SIZE; c++) {
-            if (gameState.board[r][c] === 0) {
+            if (gameState.board[r][c].value === 0) {
                 emptyCells.push({r, c});
             }
         }
@@ -156,12 +166,13 @@ function addRandomTile() {
         const maxPower = Math.log2(maxTile);
         const exponentOffset = 3 + Math.floor(Math.random() * 3); // between 3 and 5 below max
         const newExponent = Math.max(1, Math.floor(maxPower) - exponentOffset);
-        gameState.board[randomCell.r][randomCell.c] = 2 ** newExponent;
+        gameState.board[randomCell.r][randomCell.c] = createTile(2 ** newExponent);
+        gameState.lastAdded = { r: randomCell.r, c: randomCell.c };
     }
 }
 
 // Render board
-function renderBoard() {
+function renderBoard(merged = [], moveDir = null) {
     const boardElement = document.getElementById('gameBoard');
     boardElement.innerHTML = '';
     boardElement.style.gridTemplateColumns = `repeat(${BOARD_SIZE}, 1fr)`;
@@ -172,7 +183,7 @@ function renderBoard() {
             const tileElement = document.createElement('div');
             tileElement.className = 'tile';
 
-            const value = gameState.board[r][c];
+            const value = gameState.board[r][c].value;
             if (value > 0) {
                 tileElement.textContent = formatNumber(value);
                 tileElement.classList.add(`tile-${value}`);
@@ -188,16 +199,30 @@ function renderBoard() {
                 if (isQuantumTile(r, c)) {
                     tileElement.classList.add('quantum');
                 }
+
+                if (gameState.lastAdded && gameState.lastAdded.r === r && gameState.lastAdded.c === c) {
+                    tileElement.classList.add('new-tile');
+                }
+
+                if (merged.some(pos => pos.r === r && pos.c === c)) {
+                    tileElement.classList.add('merged');
+                }
+
+                if (moveDir) {
+                    tileElement.classList.add(`move-${moveDir}`);
+                }
             }
             
             boardElement.appendChild(tileElement);
         }
     }
+
+    gameState.lastAdded = null;
 }
 
 // Check if tile is quantum (has complementary neighbors)
 function isQuantumTile(r, c) {
-    const value = gameState.board[r][c];
+    const value = gameState.board[r][c].value;
     if (value === 0) return false;
     
     const color = TILE_COLORS[value];
@@ -207,7 +232,7 @@ function isQuantumTile(r, c) {
     
     for (let [nr, nc] of neighbors) {
         if (nr >= 0 && nr < BOARD_SIZE && nc >= 0 && nc < BOARD_SIZE) {
-            const neighborValue = gameState.board[nr][nc];
+            const neighborValue = gameState.board[nr][nc].value;
             if (neighborValue > 0) {
                 const neighborColor = TILE_COLORS[neighborValue];
                 if (isComplementaryColor(color, neighborColor)) {
@@ -257,7 +282,7 @@ function rotateGravity() {
 // Save game state for rewind
 function saveGameState() {
     const stateCopy = {
-        board: gameState.board.map(row => [...row]),
+        board: gameState.board.map(row => row.map(cell => ({ ...cell }))),
         score: gameState.score,
         crystals: gameState.crystals
     };
@@ -274,7 +299,7 @@ function saveGameState() {
 function rewindTime() {
     if (gameState.crystals > 0 && gameState.moveHistory.length > 0) {
         const previousState = gameState.moveHistory.pop();
-        gameState.board = previousState.board;
+        gameState.board = previousState.board.map(row => row.map(cell => ({ ...cell })));
         gameState.score = previousState.score;
         gameState.crystals = previousState.crystals - 1;
         
@@ -303,7 +328,8 @@ function move(direction) {
     saveGameState();
     let moved = false;
     let scoreGained = 0;
-    const newBoard = gameState.board.map(row => [...row]);
+    const newBoard = gameState.board.map(row => row.map(cell => ({ ...cell })));
+    const mergePositionsTransformed = [];
     
     // Transform board based on direction for easier processing
     let workingBoard = transformBoard(newBoard, direction);
@@ -315,10 +341,12 @@ function move(direction) {
         workingBoard[r] = newRow.row;
         scoreGained += newRow.score;
         if (newRow.moved) moved = true;
+        newRow.merges.forEach(idx => mergePositionsTransformed.push({ r, c: idx }));
     }
     
     // Transform back
     gameState.board = transformBoard(workingBoard, direction, true);
+    const mergePositions = mergePositionsTransformed.map(pos => transformCoord(pos.r, pos.c, direction, true));
     
     if (moved) {
         gameState.score += scoreGained;
@@ -331,7 +359,7 @@ function move(direction) {
         
         addRandomTile();
         updateDisplay();
-        renderBoard();
+        renderBoard(mergePositions, direction);
         updateBackgroundLevel();
         checkAchievements();
         createParticleEffect('merge');
@@ -345,7 +373,9 @@ function move(direction) {
 
 // Transform board for different move directions
 function transformBoard(board, direction, reverse = false) {
-    const newBoard = Array(BOARD_SIZE).fill().map(() => Array(BOARD_SIZE).fill(0));
+    const newBoard = Array.from({ length: BOARD_SIZE }, () => (
+        Array.from({ length: BOARD_SIZE }, () => createTile())
+    ));
 
     for (let r = 0; r < BOARD_SIZE; r++) {
         for (let c = 0; c < BOARD_SIZE; c++) {
@@ -362,9 +392,9 @@ function transformBoard(board, direction, reverse = false) {
             }
             
             if (reverse) {
-                newBoard[newR][newC] = board[r][c];
+                newBoard[newR][newC] = { ...board[r][c] };
             } else {
-                newBoard[r][c] = board[newR][newC];
+                newBoard[r][c] = { ...board[newR][newC] };
             }
         }
     }
@@ -372,34 +402,50 @@ function transformBoard(board, direction, reverse = false) {
     return newBoard;
 }
 
+function transformCoord(r, c, direction, reverse = false) {
+    let newR, newC;
+    if (direction === 'left') {
+        [newR, newC] = reverse ? [c, r] : [r, c];
+    } else if (direction === 'right') {
+        [newR, newC] = reverse ? [c, BOARD_SIZE - 1 - r] : [r, BOARD_SIZE - 1 - c];
+    } else if (direction === 'up') {
+        [newR, newC] = reverse ? [r, c] : [c, r];
+    } else {
+        [newR, newC] = reverse ? [BOARD_SIZE - 1 - r, c] : [BOARD_SIZE - 1 - c, r];
+    }
+    return { r: newR, c: newC };
+}
+
 // Process a single row (merge tiles to the left)
 function processRow(row) {
-    const newRow = row.filter(val => val !== 0);
+    const newRow = row.filter(tile => tile.value !== 0);
     let score = 0;
-    let moved = row.some((val, i) => val !== newRow[i] || (val === 0 && newRow[i] !== undefined));
+    let moved = row.some((tile, i) => tile.value !== (newRow[i] ? newRow[i].value : 0));
+    const merges = [];
     
     // Merge adjacent equal tiles
     for (let i = 0; i < newRow.length - 1; i++) {
-        if (newRow[i] === newRow[i + 1]) {
-            newRow[i] *= 2;
-            score += newRow[i];
+        if (newRow[i].value === newRow[i + 1].value) {
+            newRow[i] = { ...newRow[i], value: newRow[i].value * 2 };
+            score += newRow[i].value;
             
             // Check for quantum bonus
             if (Math.random() < 0.3) { // 30% chance for quantum bonus
                 score *= 2;
             }
-            
+
             newRow.splice(i + 1, 1);
+            merges.push(i);
             moved = true;
         }
     }
-    
+
     // Fill the rest with zeros
     while (newRow.length < BOARD_SIZE) {
-        newRow.push(0);
+        newRow.push(createTile());
     }
-    
-    return { row: newRow, score, moved };
+
+    return { row: newRow, score, moved, merges };
 }
 
 // Check achievements
@@ -476,20 +522,20 @@ function isGameOver() {
     // Check for empty cells
     for (let r = 0; r < BOARD_SIZE; r++) {
         for (let c = 0; c < BOARD_SIZE; c++) {
-            if (gameState.board[r][c] === 0) return false;
+            if (gameState.board[r][c].value === 0) return false;
         }
     }
     
     // Check for possible merges
     for (let r = 0; r < BOARD_SIZE; r++) {
         for (let c = 0; c < BOARD_SIZE; c++) {
-            const current = gameState.board[r][c];
+            const current = gameState.board[r][c].value;
 
             // Check right neighbor
-            if (c < BOARD_SIZE - 1 && current === gameState.board[r][c + 1]) return false;
+            if (c < BOARD_SIZE - 1 && current === gameState.board[r][c + 1].value) return false;
 
             // Check bottom neighbor
-            if (r < BOARD_SIZE - 1 && current === gameState.board[r + 1][c]) return false;
+            if (r < BOARD_SIZE - 1 && current === gameState.board[r + 1][c].value) return false;
         }
     }
     

--- a/app.js
+++ b/app.js
@@ -299,7 +299,7 @@ function saveGameState() {
 function rewindTime() {
     if (gameState.crystals > 0 && gameState.moveHistory.length > 0) {
         const previousState = gameState.moveHistory.pop();
-        gameState.board = previousState.board.map(row => row.map(cell => ({ ...cell })));
+        gameState.board = previousState.board;
         gameState.score = previousState.score;
         gameState.crystals = previousState.crystals - 1;
         

--- a/style.css
+++ b/style.css
@@ -1004,10 +1004,46 @@ body {
     animation: tileMerge var(--duration-normal) var(--ease-standard);
 }
 
+.tile.move-left {
+    animation: moveLeft var(--duration-normal) var(--ease-standard);
+}
+
+.tile.move-right {
+    animation: moveRight var(--duration-normal) var(--ease-standard);
+}
+
+.tile.move-up {
+    animation: moveUp var(--duration-normal) var(--ease-standard);
+}
+
+.tile.move-down {
+    animation: moveDown var(--duration-normal) var(--ease-standard);
+}
+
 @keyframes tileMerge {
     0% { transform: scale(1); }
     50% { transform: scale(1.2); }
     100% { transform: scale(1); }
+}
+
+@keyframes moveLeft {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(0); }
+}
+
+@keyframes moveRight {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+}
+
+@keyframes moveUp {
+    from { transform: translateY(-100%); }
+    to { transform: translateY(0); }
+}
+
+@keyframes moveDown {
+    from { transform: translateY(100%); }
+    to { transform: translateY(0); }
 }
 
 /* Particles */

--- a/style.css
+++ b/style.css
@@ -1027,22 +1027,22 @@ body {
 }
 
 @keyframes moveLeft {
-    from { transform: translateX(-100%); }
-    to { transform: translateX(0); }
-}
-
-@keyframes moveRight {
     from { transform: translateX(100%); }
     to { transform: translateX(0); }
 }
 
+@keyframes moveRight {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(0); }
+}
+
 @keyframes moveUp {
-    from { transform: translateY(-100%); }
+    from { transform: translateY(100%); }
     to { transform: translateY(0); }
 }
 
 @keyframes moveDown {
-    from { transform: translateY(100%); }
+    from { transform: translateY(-100%); }
     to { transform: translateY(0); }
 }
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -21,7 +21,9 @@ describe('touch swipe controls', () => {
 
   beforeEach(() => {
     app.gameState.gameActive = true;
-    app.gameState.board = Array(app.BOARD_SIZE).fill(null).map(() => Array(app.BOARD_SIZE).fill(0));
+    app.gameState.board = Array.from({ length: app.BOARD_SIZE }, () => (
+      Array.from({ length: app.BOARD_SIZE }, () => ({ id: null, value: 0 }))
+    ));
   });
 
   afterEach(() => {

--- a/tests/dynamicTile.test.js
+++ b/tests/dynamicTile.test.js
@@ -1,21 +1,23 @@
 const { gameState, addRandomTile, BOARD_SIZE, getMaxTile } = require('../app.js');
 
 beforeEach(() => {
-  gameState.board = Array(BOARD_SIZE).fill(null).map(() => Array(BOARD_SIZE).fill(0));
+  gameState.board = Array.from({ length: BOARD_SIZE }, () => (
+    Array.from({ length: BOARD_SIZE }, () => ({ id: null, value: 0 }))
+  ));
 });
 
 test('getMaxTile finds highest value', () => {
-  gameState.board[2][3] = 128;
+  gameState.board[2][3].value = 128;
   expect(getMaxTile(gameState.board)).toBe(128);
 });
 
 test('new tile scales with current max tile', () => {
-  gameState.board[0][0] = 64;
+  gameState.board[0][0].value = 64;
   jest.spyOn(Math, 'random')
     .mockReturnValueOnce(0) // choose first empty cell
     .mockReturnValueOnce(0); // exponent offset 3
   addRandomTile();
-  expect(gameState.board[0][1]).toBe(8);
+  expect(gameState.board[0][1].value).toBe(8);
   Math.random.mockRestore();
 });
 


### PR DESCRIPTION
## Summary
- animate board tiles moving and merging
- update tests for new board tile objects

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688776104b64832ebe771f75d83927ce