### PR TITLE
Refactor board transform logic

### DIFF
--- a/style.css
+++ b/style.css
@@ -1004,10 +1004,46 @@ body {
     animation: tileMerge var(--duration-normal) var(--ease-standard);
 }
 
+.tile.move-left {
+    animation: moveLeft var(--duration-normal) var(--ease-standard);
+}
+
+.tile.move-right {
+    animation: moveRight var(--duration-normal) var(--ease-standard);
+}
+
+.tile.move-up {
+    animation: moveUp var(--duration-normal) var(--ease-standard);
+}
+
+.tile.move-down {
+    animation: moveDown var(--duration-normal) var(--ease-standard);
+}
+
 @keyframes tileMerge {
     0% { transform: scale(1); }
     50% { transform: scale(1.2); }
     100% { transform: scale(1); }
+}
+
+@keyframes moveLeft {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(0); }
+}
+
+@keyframes moveRight {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+}
+
+@keyframes moveUp {
+    from { transform: translateY(-100%); }
+    to { transform: translateY(0); }
+}
+
+@keyframes moveDown {
+    from { transform: translateY(100%); }
+    to { transform: translateY(0); }
 }
 
 /* Particles */

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -21,7 +21,9 @@ describe('touch swipe controls', () => {
 
   beforeEach(() => {
     app.gameState.gameActive = true;
-    app.gameState.board = Array(app.BOARD_SIZE).fill(null).map(() => Array(app.BOARD_SIZE).fill(0));
+    app.gameState.board = Array.from({ length: app.BOARD_SIZE }, () => (
+      Array.from({ length: app.BOARD_SIZE }, () => ({ id: null, value: 0 }))
+    ));
   });
 
   afterEach(() => {

--- a/tests/dynamicTile.test.js
+++ b/tests/dynamicTile.test.js
@@ -1,21 +1,23 @@
 const { gameState, addRandomTile, BOARD_SIZE, getMaxTile } = require('../app.js');
 
 beforeEach(() => {
-  gameState.board = Array(BOARD_SIZE).fill(null).map(() => Array(BOARD_SIZE).fill(0));
+  gameState.board = Array.from({ length: BOARD_SIZE }, () => (
+    Array.from({ length: BOARD_SIZE }, () => ({ id: null, value: 0 }))
+  ));
 });
 
 test('getMaxTile finds highest value', () => {
-  gameState.board[2][3] = 128;
+  gameState.board[2][3].value = 128;
   expect(getMaxTile(gameState.board)).toBe(128);
 });
 
 test('new tile scales with current max tile', () => {
-  gameState.board[0][0] = 64;
+  gameState.board[0][0].value = 64;
   jest.spyOn(Math, 'random')
     .mockReturnValueOnce(0) // choose first empty cell
     .mockReturnValueOnce(0); // exponent offset 3
   addRandomTile();
-  expect(gameState.board[0][1]).toBe(8);
+  expect(gameState.board[0][1].value).toBe(8);
   Math.random.mockRestore();
 });
 

--- a/tests/transformHelpers.test.js
+++ b/tests/transformHelpers.test.js
@@ -1,0 +1,38 @@
+const { BOARD_SIZE, transformBoard, transformCoord } = require('../app.js');
+
+function makeBoard() {
+  return Array.from({ length: BOARD_SIZE }, (_, r) => (
+    Array.from({ length: BOARD_SIZE }, (_, c) => ({ id: null, value: r * BOARD_SIZE + c + 1 }))
+  ));
+}
+
+function valuesOnly(board) {
+  return board.map(row => row.map(cell => cell.value));
+}
+
+describe('transform helpers', () => {
+  const directions = ['left', 'right', 'up', 'down'];
+
+  function manualTransform(board, direction, reverse = false) {
+    const newBoard = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE));
+    for (let r = 0; r < BOARD_SIZE; r++) {
+      for (let c = 0; c < BOARD_SIZE; c++) {
+        const { r: newR, c: newC } = transformCoord(r, c, direction, reverse);
+        if (reverse) {
+          newBoard[newR][newC] = board[r][c];
+        } else {
+          newBoard[r][c] = board[newR][newC];
+        }
+      }
+    }
+    return newBoard;
+  }
+
+  test.each(directions)('forward transform %s matches manual calculation', dir => {
+    const board = makeBoard();
+    const result = transformBoard(board, dir);
+    const manual = manualTransform(board, dir);
+    expect(valuesOnly(result)).toEqual(valuesOnly(manual));
+  });
+
+});


### PR DESCRIPTION
## Summary
- centralize board coordinate logic via `transformCoord`
- export helpers for testing
- add unit tests for helper functions

## Testing
- `npx eslint .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688776104b64832ebe771f75d83927ce