### PR TITLE
Add movement-aware and quantum jump animations

### DIFF
--- a/style.css
+++ b/style.css
@@ -1024,6 +1024,10 @@ body {
     animation: tileMerge var(--duration-normal) var(--ease-standard);
 }
 
+.tile.quantum-jump {
+    animation: quantumJump var(--duration-normal) var(--ease-standard);
+}
+
 .tile.move-left {
     animation: moveLeft var(--duration-normal) var(--ease-standard);
 }
@@ -1066,6 +1070,13 @@ body {
 @keyframes moveDown {
     from { transform: translateY(-100%); }
     to { transform: translateY(0); }
+}
+
+@keyframes quantumJump {
+    0% { transform: scale(1); }
+    30% { transform: scale(1.3); }
+    60% { transform: scale(0.9); }
+    100% { transform: scale(1); }
 }
 
 /* Particles */

--- a/tests/dynamicTile.test.js
+++ b/tests/dynamicTile.test.js
@@ -1,4 +1,4 @@
-const { gameState, addRandomTile, getMaxTile, settings } = require('../app.js');
+const { gameState, addRandomTile, getMaxTile, settings, processRow } = require('../app.js');
 
 beforeEach(() => {
   gameState.board = Array.from({ length: settings.boardSize }, () => (
@@ -23,4 +23,19 @@ test('new tile scales with current max tile', () => {
 
 test('boardSize reflects expanded grid', () => {
   expect(settings.boardSize).toBe(6);
+});
+
+test('quantum bonus records jump positions', () => {
+  const row = [
+    { id: 1, value: 2 },
+    { id: 2, value: 2 },
+    { id: null, value: 0 },
+    { id: null, value: 0 },
+    { id: null, value: 0 },
+    { id: null, value: 0 }
+  ];
+  jest.spyOn(Math, 'random').mockReturnValue(0); // ensure bonus
+  const result = processRow(row);
+  expect(result.quantumJumps).toEqual([0]);
+  Math.random.mockRestore();
 });


### PR DESCRIPTION
## Summary
- animate only tiles that move and add quantum jump effects
- track quantum bonus events in game logic
- provide particle effects for quantum moves
- extend unit tests for new quantum jump tracking

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6887c0431dfc832ea07fe03419edd727