### PR TITLE
Remove finite goal from start screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
                     <li>🌀 Press SPACE to rotate gravity and make tiles fall in new directions</li>
                     <li>⏰ Press R to rewind time (uses time crystals)</li>
                     <li>✨ Match complementary colors for quantum bonuses</li>
-                    <li>🏆 Reach the white tile (256) to win!</li>
+                    <li>🏆 Keep merging tiles to reach ever higher values!</li>
                 </ul>
             </div>
             


### PR DESCRIPTION
## Summary
- update start screen instructions to highlight endless play

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6887df175094832e89c511f5fd15c4b4