### PR TITLE
Fix settings save flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -654,7 +654,6 @@ function saveSettingsFromMenu() {
 
     saveSettings();
     closeSettings();
-    newGame();
 }
 
 function resetSettingsFromMenu() {

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -50,4 +50,28 @@ describe('settings persistence', () => {
     app.saveSettingsFromMenu();
     expect(app.settings).toEqual(original);
   });
+
+  test('saving settings returns to start screen without starting game', () => {
+    document.body.innerHTML = `
+      <input id="settingBoardSize" value="6">
+      <input id="settingCrystals" value="3">
+      <input id="settingQuantumChance" value="10">
+      <input id="settingHistory" value="5">
+      <div id="score"></div>
+      <div id="bestScore"></div>
+      <div id="crystalCount"></div>
+      <div id="gravityArrow"></div>
+      <button id="rewindButton"></button>
+      <div id="gameBoard"></div>
+      <div id="gameScreen" class="screen hidden"></div>
+      <div id="gameOverScreen"></div>
+      <div id="particlesContainer"></div>
+      <div id="startScreen" class="screen hidden"></div>
+      <div id="settingsScreen" class="screen"></div>
+    `;
+    const app = require('../app.js');
+    app.saveSettingsFromMenu();
+    expect(document.getElementById('startScreen').classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('gameScreen').classList.contains('hidden')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- stop starting a new game when saving settings
- ensure the settings menu returns to the start screen
- test the settings flow

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6887e0234a0c832eb13be0ed98ddc625