### PR TITLE
Fix transform logic and tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -472,16 +472,16 @@ function transformBoard(board, direction, reverse = false) {
     return newBoard;
 }
 
-function transformCoord(r, c, direction, reverse = false) {
+function transformCoord(r, c, direction) {
     let newR, newC;
     if (direction === 'left') {
-        [newR, newC] = reverse ? [c, r] : [r, c];
+        [newR, newC] = [r, c];
     } else if (direction === 'right') {
-        [newR, newC] = reverse ? [c, settings.boardSize - 1 - r] : [r, settings.boardSize - 1 - c];
+        [newR, newC] = [r, settings.boardSize - 1 - c];
     } else if (direction === 'up') {
-        [newR, newC] = reverse ? [r, c] : [c, r];
+        [newR, newC] = [c, r];
     } else {
-        [newR, newC] = reverse ? [settings.boardSize - 1 - r, c] : [settings.boardSize - 1 - c, r];
+        [newR, newC] = [settings.boardSize - 1 - c, r];
     }
     return { r: newR, c: newC };
 }

--- a/tests/transformHelpers.test.js
+++ b/tests/transformHelpers.test.js
@@ -37,4 +37,11 @@ describe('transform helpers', () => {
     expect(valuesOnly(result)).toEqual(valuesOnly(manual));
   });
 
+  test.each(directions)('round trip transform %s returns original board', dir => {
+    const board = makeBoard();
+    const transformed = transformBoard(board, dir);
+    const roundTripped = transformBoard(transformed, dir, true);
+    expect(valuesOnly(roundTripped)).toEqual(valuesOnly(board));
+  });
+
 });


### PR DESCRIPTION
## Summary
- ensure board coordinates map correctly by simplifying `transformCoord`
- test that transform helpers are reversible

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_688883af00a0832e9abb3de600d7446f