### PR TITLE
Fix tile spawn order

### DIFF
--- a/app.js
+++ b/app.js
@@ -434,9 +434,11 @@ function move(direction) {
             localStorage.setItem('quantum2048_best', gameState.bestScore.toString());
         }
         
-        addRandomTile();
         updateDisplay();
         renderBoard(mergePositions, direction, movedPositions, quantumPositions);
+
+        addRandomTile();
+        renderBoard();
         updateBackgroundLevel();
         checkAchievements();
         if (quantumPositions.length > 0) {
@@ -444,7 +446,7 @@ function move(direction) {
         } else {
             createParticleEffect('merge');
         }
-        
+
         // Check game over
         if (isGameOver()) {
             setTimeout(endGame, 500);

--- a/app.js
+++ b/app.js
@@ -437,20 +437,28 @@ function move(direction) {
         updateDisplay();
         renderBoard(mergePositions, direction, movedPositions, quantumPositions);
 
-        addRandomTile();
-        renderBoard();
-        updateBackgroundLevel();
-        checkAchievements();
-        if (quantumPositions.length > 0) {
-            createParticleEffect('quantum');
-        } else {
-            createParticleEffect('merge');
-        }
+        // Wait for merge animations to finish before spawning new tile.
+        // Disable input during the animation to avoid inconsistencies.
+        gameState.gameActive = false;
+        setTimeout(() => {
+            addRandomTile();
+            renderBoard();
+            updateBackgroundLevel();
+            checkAchievements();
 
-        // Check game over
-        if (isGameOver()) {
-            setTimeout(endGame, 500);
-        }
+            if (quantumPositions.length > 0) {
+                createParticleEffect('quantum');
+            } else {
+                createParticleEffect('merge');
+            }
+
+            // Check game over after the new tile is placed
+            if (isGameOver()) {
+                setTimeout(endGame, 500);
+            } else {
+                gameState.gameActive = true;
+            }
+        }, 250); // Match animation duration from CSS (--duration-normal)
     }
 }
 

--- a/tests/moveSpawn.test.js
+++ b/tests/moveSpawn.test.js
@@ -1,0 +1,38 @@
+function setupDom() {
+  const html = `
+    <div id="score"></div>
+    <div id="bestScore"></div>
+    <div id="crystalCount"></div>
+    <div id="gravityArrow"></div>
+    <button id="rewindButton"></button>
+    <div id="gameBoard"></div>
+    <div id="gameScreen"></div>
+    <div id="particlesContainer"></div>
+  `;
+  document.body.innerHTML = html;
+}
+setupDom();
+const { gameState, move, settings } = require('../app.js');
+
+beforeEach(() => {
+  gameState.board = Array.from({ length: settings.boardSize }, () => (
+    Array.from({ length: settings.boardSize }, () => ({ id: null, value: 0 }))
+  ));
+  gameState.gameActive = true;
+});
+
+test('move merges tiles before spawning new one', () => {
+  // Arrange board so first row has two tiles to merge
+  gameState.board[0][0].value = 2;
+  gameState.board[0][1].value = 2;
+  jest
+    .spyOn(Math, 'random')
+    .mockReturnValueOnce(0) // choose first empty cell (0,1) after merge
+    .mockReturnValueOnce(0); // exponent offset
+  // Act
+  move('left');
+  // Assert
+  expect(gameState.board[0][0].value).toBe(4);
+  expect(gameState.board[0][1].value).toBe(2);
+  Math.random.mockRestore();
+});

--- a/tests/moveSpawn.test.js
+++ b/tests/moveSpawn.test.js
@@ -19,6 +19,12 @@ beforeEach(() => {
     Array.from({ length: settings.boardSize }, () => ({ id: null, value: 0 }))
   ));
   gameState.gameActive = true;
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  Math.random.mockRestore();
+  jest.useRealTimers();
 });
 
 test('move merges tiles before spawning new one', () => {
@@ -31,8 +37,10 @@ test('move merges tiles before spawning new one', () => {
     .mockReturnValueOnce(0); // exponent offset
   // Act
   move('left');
+  // Fast-forward time to execute the setTimeout callback
+  jest.runAllTimers();
+
   // Assert
   expect(gameState.board[0][0].value).toBe(4);
   expect(gameState.board[0][1].value).toBe(2);
-  Math.random.mockRestore();
 });


### PR DESCRIPTION
## Summary
- fix tile spawn order by rendering merges first then spawning tiles
- add regression test ensuring merge happens before new tile spawns

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6888884550ec832ebba6dc989221db80