### PR TITLE
Improve merge tile animations

### DIFF
--- a/style.css
+++ b/style.css
@@ -1061,20 +1061,8 @@ body {
     animation: quantumJump var(--duration-normal) var(--ease-standard);
 }
 
-.tile.move-left {
-    animation: moveLeft var(--duration-normal) var(--ease-standard);
-}
-
-.tile.move-right {
-    animation: moveRight var(--duration-normal) var(--ease-standard);
-}
-
-.tile.move-up {
-    animation: moveUp var(--duration-normal) var(--ease-standard);
-}
-
-.tile.move-down {
-    animation: moveDown var(--duration-normal) var(--ease-standard);
+.tile.move {
+    animation: moveTile var(--duration-normal) var(--ease-standard);
 }
 
 @keyframes tileMerge {
@@ -1092,26 +1080,14 @@ body {
     }
 }
 
-@keyframes moveLeft {
-    from { transform: translateX(100%); }
-
-    to { transform: translateX(0); }
-}
-
-@keyframes moveRight {
-    from { transform: translateX(-100%); }
-
-    to { transform: translateX(0); }
-}
-
-@keyframes moveUp {
-    from { transform: translateY(100%); }
-    to { transform: translateY(0); }
-}
-
-@keyframes moveDown {
-    from { transform: translateY(-100%); }
-    to { transform: translateY(0); }
+@keyframes moveTile {
+    from {
+        transform: translate(
+            calc(var(--dx, 0) * 100%),
+            calc(var(--dy, 0) * 100%)
+        );
+    }
+    to { transform: translate(0, 0); }
 }
 
 @keyframes quantumJump {

--- a/tests/movement.test.js
+++ b/tests/movement.test.js
@@ -1,0 +1,37 @@
+const { gameState, move, settings } = require('../app.js');
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="score"></div>
+    <div id="bestScore"></div>
+    <div id="crystalCount"></div>
+    <div id="gravityArrow"></div>
+    <button id="rewindButton"></button>
+    <div id="gameBoard"></div>
+    <div id="gameScreen"></div>
+    <div id="particlesContainer"></div>
+    <div id="achievementPopup" class="hidden"></div>
+    <div id="achievementText"></div>
+  `;
+}
+
+describe('movement animation', () => {
+  beforeEach(() => {
+    setupDom();
+    gameState.board = Array.from({ length: settings.boardSize }, () => (
+      Array.from({ length: settings.boardSize }, () => ({ id: null, value: 0 }))
+    ));
+    gameState.nextId = 2;
+    gameState.gameActive = true;
+    gameState.score = 0;
+  });
+
+  test('tile moving multiple spaces sets translation variables', () => {
+    gameState.board[0][3] = { id: 1, value: 2 };
+    move('left');
+    const firstTile = document.getElementById('gameBoard').children[0];
+    expect(firstTile.classList.contains('move')).toBe(true);
+    expect(firstTile.style.getPropertyValue('--dx')).toBe('3');
+    expect(firstTile.style.getPropertyValue('--dy')).toBe('0');
+  });
+});

--- a/tests/movement.test.js
+++ b/tests/movement.test.js
@@ -34,4 +34,34 @@ describe('movement animation', () => {
     expect(firstTile.style.getPropertyValue('--dx')).toBe('3');
     expect(firstTile.style.getPropertyValue('--dy')).toBe('0');
   });
+
+  test('merged tile animates from second tile', () => {
+    gameState.board[0][0] = { id: 1, value: 2 };
+    gameState.board[0][1] = { id: 2, value: 2 };
+    move('left');
+    const tile = document.getElementById('gameBoard').children[0];
+    expect(tile.classList.contains('move')).toBe(true);
+    expect(tile.style.getPropertyValue('--dx')).toBe('1');
+  });
+
+  test('merge with gap uses correct source tile', () => {
+    gameState.board[0][0] = { id: 1, value: 2 };
+    gameState.board[0][2] = { id: 2, value: 2 };
+    move('left');
+    const tile = document.getElementById('gameBoard').children[0];
+    expect(tile.classList.contains('move')).toBe(true);
+    expect(tile.style.getPropertyValue('--dx')).toBe('2');
+  });
+
+  test('multiple merges calculate proper sources', () => {
+    gameState.board[0][0] = { id: 1, value: 2 };
+    gameState.board[0][1] = { id: 2, value: 2 };
+    gameState.board[0][2] = { id: 3, value: 4 };
+    gameState.board[0][3] = { id: 4, value: 4 };
+    move('left');
+    const boardEl = document.getElementById('gameBoard');
+    const secondTile = boardEl.children[1];
+    expect(secondTile.classList.contains('move')).toBe(true);
+    expect(secondTile.style.getPropertyValue('--dx')).toBe('2');
+  });
 });


### PR DESCRIPTION
## Summary
- enhance move detection and apply per-tile movement using CSS variables
- replace direction-specific animations with generic `moveTile`
- export `renderBoard` for tests
- add regression test verifying movement animation variables

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688887bfdbc8832ea8bae0895fc5411c