### PR TITLE
Add settings integration tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -796,6 +796,9 @@ if (typeof module !== 'undefined' && module.exports) {
         saveSettingsFromMenu,
         resetSettings,
         settings,
-        processRow
+        processRow,
+        startGame,
+        newGame,
+        initGame
     };
 }

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -74,4 +74,71 @@ describe('settings persistence', () => {
     expect(document.getElementById('startScreen').classList.contains('hidden')).toBe(false);
     expect(document.getElementById('gameScreen').classList.contains('hidden')).toBe(true);
   });
+
+  test('new game uses persisted settings', () => {
+    document.body.innerHTML = `
+      <div id="score"></div>
+      <div id="bestScore"></div>
+      <div id="crystalCount"></div>
+      <div id="gravityArrow"></div>
+      <button id="rewindButton"></button>
+      <div id="gameBoard"></div>
+      <div id="gameScreen"></div>
+      <div id="gameOverScreen"></div>
+      <div id="particlesContainer"></div>
+      <div id="startScreen"></div>
+      <div id="settingsScreen"></div>
+    `;
+
+    let app = require('../app.js');
+    app.settings.boardSize = 5;
+    app.settings.startingCrystals = 2;
+    app.saveSettings();
+
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div id="score"></div>
+      <div id="bestScore"></div>
+      <div id="crystalCount"></div>
+      <div id="gravityArrow"></div>
+      <button id="rewindButton"></button>
+      <div id="gameBoard"></div>
+      <div id="gameScreen"></div>
+      <div id="gameOverScreen"></div>
+      <div id="particlesContainer"></div>
+      <div id="startScreen"></div>
+      <div id="settingsScreen"></div>
+    `;
+    app = require('../app.js');
+    app.startGame();
+
+    expect(app.gameState.board.length).toBe(5);
+    expect(app.gameState.board[0].length).toBe(5);
+    expect(app.gameState.crystals).toBe(2);
+  });
+
+  test('reset settings affects subsequent games', () => {
+    document.body.innerHTML = `
+      <div id="score"></div>
+      <div id="bestScore"></div>
+      <div id="crystalCount"></div>
+      <div id="gravityArrow"></div>
+      <button id="rewindButton"></button>
+      <div id="gameBoard"></div>
+      <div id="gameScreen"></div>
+      <div id="gameOverScreen"></div>
+      <div id="particlesContainer"></div>
+      <div id="startScreen"></div>
+      <div id="settingsScreen"></div>
+    `;
+
+    const app = require('../app.js');
+    app.settings.boardSize = 7;
+    app.settings.startingCrystals = 5;
+    app.resetSettings();
+    app.startGame();
+
+    expect(app.gameState.board.length).toBe(6);
+    expect(app.gameState.crystals).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary
- export `startGame`, `newGame` and `initGame` so tests can initialize games
- extend settings tests to verify persisted and reset settings influence new games

## Testing
- `npm test --silent`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_68888d9f2a7c832e821cc02de8e59480