### PR TITLE
Improve rewind animation

### DIFF
--- a/app.js
+++ b/app.js
@@ -352,12 +352,48 @@ function saveGameState() {
 function rewindTime() {
     if (gameState.crystals > 0 && gameState.moveHistory.length > 0) {
         const previousState = gameState.moveHistory.pop();
-        gameState.board = previousState.board.map(row => row.map(cell => ({ ...cell })));
+
+        const currentBoard = gameState.board;
+        const prevBoard = previousState.board.map(row => row.map(cell => ({ ...cell })));
+
+        const currentPositions = new Map();
+        for (let r = 0; r < settings.boardSize; r++) {
+            for (let c = 0; c < settings.boardSize; c++) {
+                const tile = currentBoard[r][c];
+                if (tile.id !== null) {
+                    currentPositions.set(tile.id, { r, c });
+                }
+            }
+        }
+
+        const movedTiles = [];
+        for (let r = 0; r < settings.boardSize; r++) {
+            for (let c = 0; c < settings.boardSize; c++) {
+                const tile = prevBoard[r][c];
+                if (tile.id !== null) {
+                    const currPos = currentPositions.get(tile.id);
+                    if (currPos && (currPos.r !== r || currPos.c !== c)) {
+                        movedTiles.push({
+                            r,
+                            c,
+                            dr: currPos.r - r,
+                            dc: currPos.c - c
+                        });
+                    }
+                }
+            }
+        }
+
+        gameState.board = prevBoard;
         gameState.score = previousState.score;
         gameState.crystals = previousState.crystals - 1;
-        
+
         updateDisplay();
-        renderBoard();
+        renderBoard([], movedTiles);
+        gameState.gameActive = false;
+        setTimeout(() => {
+            gameState.gameActive = true;
+        }, 250);
         createParticleEffect('time');
     }
 }
@@ -846,6 +882,8 @@ if (typeof module !== 'undefined' && module.exports) {
         resetSettings,
         settings,
         processRow,
-        renderBoard
+        renderBoard,
+        saveGameState,
+        rewindTime
     };
 }

--- a/tests/rewind.test.js
+++ b/tests/rewind.test.js
@@ -1,0 +1,53 @@
+const { gameState, settings, saveGameState, rewindTime, renderBoard } = require('../app.js');
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="score"></div>
+    <div id="bestScore"></div>
+    <div id="crystalCount"></div>
+    <div id="gravityArrow"></div>
+    <button id="rewindButton"></button>
+    <div id="gameBoard"></div>
+    <div id="gameScreen"></div>
+    <div id="particlesContainer"></div>
+  `;
+}
+
+beforeEach(() => {
+  setupDom();
+  gameState.board = Array.from({ length: settings.boardSize }, () => (
+    Array.from({ length: settings.boardSize }, () => ({ id: null, value: 0 }))
+  ));
+  gameState.moveHistory = [];
+  gameState.crystals = 2;
+  gameState.score = 0;
+  gameState.gameActive = true;
+  gameState.nextId = 2;
+});
+
+test('rewind animates tiles back to previous state', () => {
+  // initial tile
+  gameState.board[0][0] = { id: 1, value: 2 };
+  saveGameState();
+
+  // simulate moved tile
+  gameState.board[0][0] = { id: null, value: 0 };
+  gameState.board[0][3] = { id: 1, value: 2 };
+  renderBoard();
+
+  rewindTime();
+  const boardEl = document.getElementById('gameBoard');
+  const firstTile = boardEl.children[0];
+
+  expect(gameState.board[0][0].id).toBe(1);
+  expect(gameState.crystals).toBe(1);
+  expect(firstTile.classList.contains('move')).toBe(true);
+  expect(firstTile.style.getPropertyValue('--dx')).toBe('3');
+});
+
+test('rewind without history does nothing', () => {
+  gameState.crystals = 1;
+  // no moveHistory
+  rewindTime();
+  expect(gameState.crystals).toBe(1);
+});


### PR DESCRIPTION
## Summary
- animate tiles when rewinding
- expose rewind helpers for tests
- cover rewind behavior with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68888f30ee48832eaad958f4002cf233