### PR TITLE
Fix move input queueing for repeated moves

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,9 @@ let gameState = {
     lastAdded: null
 };
 
+// Queue for storing pending move directions when a move is already in progress
+const moveQueue = [];
+
 // Game configuration
 const TILE_COLORS = {
     2: '#ff6b6b',
@@ -376,7 +379,10 @@ function getMoveDirection(key) {
 
 // Move tiles
 function move(direction) {
-    if (!gameState.gameActive) return;
+    if (!gameState.gameActive) {
+        moveQueue.push(direction);
+        return;
+    }
 
     saveGameState();
     const previousBoard = gameState.board.map(row => row.map(cell => ({ ...cell })));
@@ -488,8 +494,16 @@ function move(direction) {
                 setTimeout(endGame, 500);
             } else {
                 gameState.gameActive = true;
+                if (moveQueue.length > 0) {
+                    const next = moveQueue.shift();
+                    move(next);
+                }
             }
         }, 250); // Match animation duration from CSS (--duration-normal)
+    } else if (moveQueue.length > 0) {
+        // No tiles moved, process any queued moves immediately
+        const next = moveQueue.shift();
+        move(next);
     }
 }
 
@@ -846,6 +860,7 @@ if (typeof module !== 'undefined' && module.exports) {
         resetSettings,
         settings,
         processRow,
-        renderBoard
+        renderBoard,
+        moveQueue
     };
 }

--- a/tests/moveQueue.test.js
+++ b/tests/moveQueue.test.js
@@ -1,0 +1,50 @@
+const { gameState, move, settings, moveQueue } = require('../app.js');
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="score"></div>
+    <div id="bestScore"></div>
+    <div id="crystalCount"></div>
+    <div id="gravityArrow"></div>
+    <button id="rewindButton"></button>
+    <div id="gameBoard"></div>
+    <div id="gameScreen"></div>
+    <div id="particlesContainer"></div>
+  `;
+}
+
+beforeEach(() => {
+  setupDom();
+  gameState.board = Array.from({ length: settings.boardSize }, () => (
+    Array.from({ length: settings.boardSize }, () => ({ id: null, value: 0 }))
+  ));
+  gameState.nextId = 2;
+  gameState.gameActive = true;
+  moveQueue.length = 0;
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  Math.random.mockRestore();
+  jest.useRealTimers();
+});
+
+test('queued moves execute after current move', () => {
+  // Place single tile at end of row
+  gameState.board[0][5] = { id: 1, value: 2 };
+  jest
+    .spyOn(Math, 'random')
+    .mockReturnValueOnce(0) // spawn at (0,1) after first move
+    .mockReturnValueOnce(0)
+    .mockReturnValueOnce(0) // spawn after second move
+    .mockReturnValueOnce(0);
+
+  move('left');
+  // This call should be queued because first move is in progress
+  move('left');
+  // run timers for both moves
+  jest.runAllTimers();
+
+  expect(gameState.board[0][0].value).toBe(4);
+  expect(moveQueue.length).toBe(0);
+});


### PR DESCRIPTION
## Summary
- enable queuing of moves when a move is already in progress
- test move queueing to ensure repeated moves work

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68888eb6c8c0832e96ab254c74a46ec2