### PR TITLE
Implement dynamic tile spawning

### DIFF
--- a/app.js
+++ b/app.js
@@ -135,10 +135,11 @@ function createTile(value = 0) {
     return { id: value === 0 ? null : gameState.nextId++, value };
 }
 
-// Determine initial crystal count based on board size
-function getInitialCrystals(boardSize) {
+// Determine how many tiles should spawn at game start and after each move
+// based on the board size. At minimum one tile will appear.
+function getTilesPerStep(boardSize) {
     const sizeBased = Math.floor(boardSize / 2) - 1;
-    return Math.max(settings.startingCrystals, sizeBased);
+    return Math.max(1, sizeBased);
 }
 
 // Initialize game
@@ -158,14 +159,13 @@ function initGame() {
     gameState.nextId = 1;
     gameState.lastAdded = null;
     gameState.score = 0;
-    gameState.crystals = getInitialCrystals(settings.boardSize);
+    gameState.crystals = settings.startingCrystals;
     gameState.gravity = 'south';
     gameState.moveHistory = [];
     gameState.gameActive = true;
     
-    // Add initial tiles
-    addRandomTile();
-    addRandomTile();
+    // Add initial tiles based on board size
+    addRandomTiles(getTilesPerStep(settings.boardSize));
     
     updateDisplay();
     renderBoard();
@@ -212,6 +212,13 @@ function addRandomTile() {
         const newExponent = Math.max(1, Math.floor(maxPower) - exponentOffset);
         gameState.board[randomCell.r][randomCell.c] = createTile(2 ** newExponent);
         gameState.lastAdded = { r: randomCell.r, c: randomCell.c };
+    }
+}
+
+// Spawn multiple random tiles
+function addRandomTiles(count) {
+    for (let i = 0; i < count; i++) {
+        addRandomTile();
     }
 }
 
@@ -520,7 +527,7 @@ function move(direction) {
         // Disable input during the animation to avoid inconsistencies.
         gameState.gameActive = false;
         setTimeout(() => {
-            addRandomTile();
+            addRandomTiles(getTilesPerStep(settings.boardSize));
             renderBoard();
             updateBackgroundLevel();
             checkAchievements();
@@ -895,6 +902,7 @@ if (typeof module !== 'undefined' && module.exports) {
         transformBoard,
         transformCoord,
         addRandomTile,
+        addRandomTiles,
         getMaxTile,
         loadSettings,
         saveSettings,
@@ -902,7 +910,7 @@ if (typeof module !== 'undefined' && module.exports) {
         resetSettings,
         settings,
         processRow,
-        getInitialCrystals,
+        getTilesPerStep,
         moveQueue,
         saveGameState,
         rewindTime,

--- a/tests/initialCrystals.test.js
+++ b/tests/initialCrystals.test.js
@@ -26,14 +26,8 @@ describe('initial crystal spawn', () => {
     settings.boardSize = originalBoardSize;
   });
 
-  test('larger boards grant additional crystals', () => {
+  test('initGame uses starting crystals regardless of board size', () => {
     settings.boardSize = 10;
-    initGame();
-    expect(gameState.crystals).toBe(4);
-  });
-
-  test('smaller boards use starting crystals', () => {
-    settings.boardSize = 4;
     initGame();
     expect(gameState.crystals).toBe(settings.startingCrystals);
   });

--- a/tests/moveQueue.test.js
+++ b/tests/moveQueue.test.js
@@ -32,12 +32,7 @@ afterEach(() => {
 test('queued moves execute after current move', () => {
   // Place single tile at end of row
   gameState.board[0][5] = { id: 1, value: 2 };
-  jest
-    .spyOn(Math, 'random')
-    .mockReturnValueOnce(0) // spawn at (0,1) after first move
-    .mockReturnValueOnce(0)
-    .mockReturnValueOnce(0) // spawn after second move
-    .mockReturnValueOnce(0);
+  jest.spyOn(Math, 'random').mockReturnValue(0);
 
   move('left');
   // This call should be queued because first move is in progress

--- a/tests/moveSpawn.test.js
+++ b/tests/moveSpawn.test.js
@@ -27,14 +27,11 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-test('move merges tiles before spawning new one', () => {
+test('move merges tiles before spawning new ones', () => {
   // Arrange board so first row has two tiles to merge
   gameState.board[0][0].value = 2;
   gameState.board[0][1].value = 2;
-  jest
-    .spyOn(Math, 'random')
-    .mockReturnValueOnce(0) // choose first empty cell (0,1) after merge
-    .mockReturnValueOnce(0); // exponent offset
+  jest.spyOn(Math, 'random').mockReturnValue(0);
   // Act
   move('left');
   // Fast-forward time to execute the setTimeout callback
@@ -43,4 +40,5 @@ test('move merges tiles before spawning new one', () => {
   // Assert
   expect(gameState.board[0][0].value).toBe(4);
   expect(gameState.board[0][1].value).toBe(2);
+  expect(gameState.board[0][2].value).toBe(2);
 });


### PR DESCRIPTION
## Summary
- rename `getInitialCrystals` to `getTilesPerStep`
- spawn multiple random tiles using `addRandomTiles`
- base crystal count only on settings
- update tests for new spawn behavior

## Testing
- `npm ci`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6888a66cb8a0832e9cf1493b78e0ce35