### PR TITLE
Enhance experimental block visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The design also introduces several advanced tile behaviors:
 
 These experimental blocks push the traditional mechanics into new territory, encouraging daring strategies and careful timing.
 
+Each block type is styled with its own border color and effects so they are easy to spot during play.
+
 
 ## Continuous Integration
 This project uses GitHub Actions to run ESLint and Jest on every push and pull request.

--- a/app.js
+++ b/app.js
@@ -338,6 +338,11 @@ function renderBoard(merged = [], movedTiles = [], quantumTiles = []) {
                 const isPredefinedColor = Object.prototype.hasOwnProperty.call(TILE_COLORS, value);
                 tileElement.style.backgroundColor = getTileColor(value);
 
+                const type = gameState.board[r][c].type;
+                if (type && type !== 'normal') {
+                    tileElement.classList.add(type);
+                }
+
                 // Ensure text is readable for generated colors
                 if (!isPredefinedColor) {
                     tileElement.style.color = '#fff';

--- a/style.css
+++ b/style.css
@@ -1001,6 +1001,25 @@ body {
 .tile.tile-512 { background: gold; color: #333; }
 .tile.tile-1024 { background: #e5e4e2; color: #111; }
 
+/* Experimental tile styles */
+.tile.phase {
+    box-shadow: 0 0 0 3px var(--color-warning);
+    animation: phaseBlink 1s steps(2, start) infinite;
+}
+
+.tile.echo {
+    box-shadow: 0 0 0 3px var(--color-info);
+}
+
+.tile.portal {
+    box-shadow: 0 0 0 3px var(--color-success);
+    border-radius: var(--radius-full);
+}
+
+@keyframes phaseBlink {
+    50% { opacity: 0.4; }
+}
+
 .tile.quantum {
     position: relative;
     animation: quantumPulseScale 2s infinite cubic-bezier(0.4, 0, 0.6, 1);

--- a/tests/experimentalClasses.test.js
+++ b/tests/experimentalClasses.test.js
@@ -1,4 +1,11 @@
-const { gameState, settings, renderBoard, spawnPhaseShiftTile, spawnEchoDuplicateTile, spawnNexusPortalTile } = require('../app.js');
+const {
+  gameState,
+  settings,
+  renderBoard,
+  spawnPhaseShiftTile,
+  spawnEchoDuplicateTile,
+  spawnNexusPortalTile
+} = require('../app.js');
 
 function setupDom() {
   document.body.innerHTML = `
@@ -19,23 +26,15 @@ beforeEach(() => {
   gameState.gameActive = true;
 });
 
-test('phase shift tiles use phase class', () => {
-  spawnPhaseShiftTile(0, 0, 2);
-  renderBoard();
-  const tile = document.getElementById('gameBoard').children[0];
-  expect(tile.classList.contains('phase')).toBe(true);
-});
+const cases = [
+  ['phase shift', spawnPhaseShiftTile, 'phase'],
+  ['echo duplicate', spawnEchoDuplicateTile, 'echo'],
+  ['nexus portal', spawnNexusPortalTile, 'portal']
+];
 
-test('echo duplicate tiles use echo class', () => {
-  spawnEchoDuplicateTile(0, 0, 2);
+test.each(cases)('%s tiles use %s class', (_name, spawnFn, className) => {
+  spawnFn(0, 0, 2);
   renderBoard();
   const tile = document.getElementById('gameBoard').children[0];
-  expect(tile.classList.contains('echo')).toBe(true);
-});
-
-test('nexus portal tiles use portal class', () => {
-  spawnNexusPortalTile(0, 0, 2);
-  renderBoard();
-  const tile = document.getElementById('gameBoard').children[0];
-  expect(tile.classList.contains('portal')).toBe(true);
+  expect(tile.classList.contains(className)).toBe(true);
 });

--- a/tests/experimentalClasses.test.js
+++ b/tests/experimentalClasses.test.js
@@ -1,0 +1,41 @@
+const { gameState, settings, renderBoard, spawnPhaseShiftTile, spawnEchoDuplicateTile, spawnNexusPortalTile } = require('../app.js');
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="score"></div>
+    <div id="bestScore"></div>
+    <div id="crystalCount"></div>
+    <div id="gravityArrow"></div>
+    <button id="rewindButton"></button>
+    <div id="gameBoard"></div>
+  `;
+}
+
+beforeEach(() => {
+  setupDom();
+  gameState.board = Array.from({ length: settings.boardSize }, () => (
+    Array.from({ length: settings.boardSize }, () => ({ id: null, value: 0 }))
+  ));
+  gameState.gameActive = true;
+});
+
+test('phase shift tiles use phase class', () => {
+  spawnPhaseShiftTile(0, 0, 2);
+  renderBoard();
+  const tile = document.getElementById('gameBoard').children[0];
+  expect(tile.classList.contains('phase')).toBe(true);
+});
+
+test('echo duplicate tiles use echo class', () => {
+  spawnEchoDuplicateTile(0, 0, 2);
+  renderBoard();
+  const tile = document.getElementById('gameBoard').children[0];
+  expect(tile.classList.contains('echo')).toBe(true);
+});
+
+test('nexus portal tiles use portal class', () => {
+  spawnNexusPortalTile(0, 0, 2);
+  renderBoard();
+  const tile = document.getElementById('gameBoard').children[0];
+  expect(tile.classList.contains('portal')).toBe(true);
+});


### PR DESCRIPTION
## Summary
- style experimental tiles with unique borders and animations
- add rendering logic for experimental tile classes
- document new visuals in README
- test class names for experimental tiles

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6889e221f5b4832e8c681136315482a1