### PR TITLE
Add short form notation for scores

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,13 @@ function formatNumber(num) {
     return `${value}${suffix}`;
 }
 
+// Format score display to include a short form when applicable
+function formatScoreDisplay(num) {
+    const short = formatNumber(num);
+    const full = num.toLocaleString();
+    return short === full ? full : `${full} (${short})`;
+}
+
 // Find the highest tile on the board without flattening the array
 function getMaxTile(board) {
     let max = 0;
@@ -409,8 +416,8 @@ function isComplementaryColor(color1, color2) {
 
 // Update display
 function updateDisplay() {
-    document.getElementById('score').textContent = gameState.score;
-    document.getElementById('bestScore').textContent = gameState.bestScore;
+    document.getElementById('score').textContent = formatScoreDisplay(gameState.score);
+    document.getElementById('bestScore').textContent = formatScoreDisplay(gameState.bestScore);
     document.getElementById('crystalCount').textContent = gameState.crystals;
     document.getElementById('gravityArrow').textContent = GRAVITY_ARROWS[gameState.gravity];
     
@@ -949,7 +956,7 @@ function isGameOver() {
 // End game
 function endGame() {
     gameState.gameActive = false;
-    document.getElementById('finalScore').textContent = gameState.score;
+    document.getElementById('finalScore').textContent = formatScoreDisplay(gameState.score);
     document.getElementById('gameScreen').classList.add('hidden');
     document.getElementById('gameOverScreen').classList.remove('hidden');
     
@@ -1151,6 +1158,8 @@ if (typeof module !== 'undefined' && module.exports) {
         spawnEchoDuplicateTile,
         spawnNexusPortalTile,
         performQuantumJumps,
-        updateScore
+        updateScore,
+        updateDisplay,
+        formatScoreDisplay
     };
 }

--- a/app.js
+++ b/app.js
@@ -112,7 +112,8 @@ function formatNumber(num) {
 function formatScoreDisplay(num) {
     const short = formatNumber(num);
     const full = num.toLocaleString();
-    return short === full ? full : `${full} (${short})`;
+    // If formatNumber didn't abbreviate the value, just return the locale string
+    return short === String(num) ? full : `${full} (${short})`;
 }
 
 // Find the highest tile on the board without flattening the array

--- a/tests/scoreDisplay.test.js
+++ b/tests/scoreDisplay.test.js
@@ -31,3 +31,12 @@ test('updateDisplay shows raw numbers for small scores', () => {
   expect(document.getElementById('score').textContent).toBe('512');
   expect(document.getElementById('bestScore').textContent).toBe('256');
 });
+
+test('updateDisplay shows formatted numbers for scores between 1,000 and 9,999', () => {
+  const app = require('../app.js');
+  app.gameState.score = 1234;
+  app.gameState.bestScore = 9999;
+  app.updateDisplay();
+  expect(document.getElementById('score').textContent).toBe('1,234');
+  expect(document.getElementById('bestScore').textContent).toBe('9,999');
+});

--- a/tests/scoreDisplay.test.js
+++ b/tests/scoreDisplay.test.js
@@ -1,0 +1,33 @@
+const setupDom = () => {
+  document.body.innerHTML = `
+    <div id="score"></div>
+    <div id="bestScore"></div>
+    <div id="crystalCount"></div>
+    <div id="gravityArrow"></div>
+    <button id="rewindButton"></button>
+    <div id="gameBoard"></div>
+  `;
+};
+
+beforeEach(() => {
+  jest.resetModules();
+  setupDom();
+});
+
+test('updateDisplay shows short form for large scores', () => {
+  const app = require('../app.js');
+  app.gameState.score = 123456;
+  app.gameState.bestScore = 54321;
+  app.updateDisplay();
+  expect(document.getElementById('score').textContent).toBe('123,456 (123k)');
+  expect(document.getElementById('bestScore').textContent).toBe('54,321 (54k)');
+});
+
+test('updateDisplay shows raw numbers for small scores', () => {
+  const app = require('../app.js');
+  app.gameState.score = 512;
+  app.gameState.bestScore = 256;
+  app.updateDisplay();
+  expect(document.getElementById('score').textContent).toBe('512');
+  expect(document.getElementById('bestScore').textContent).toBe('256');
+});


### PR DESCRIPTION
## Summary
- display scores with numeric and short-form notation
- show short scores at game over
- expose new helpers for testing
- cover score formatting with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6889e3ceea28832eaf39135c439a8925