### PR TITLE
[Feat]: style and position language toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <div class="language-switch">
         <label for="languageSelect" data-i18n="label_language">Language</label>
-        <select id="languageSelect" onchange="handleLanguageChange(this.value)">
+        <select id="languageSelect" class="form-control" onchange="handleLanguageChange(this.value)">
             <option value="en">English</option>
             <option value="ru">Русский</option>
         </select>

--- a/style.css
+++ b/style.css
@@ -748,6 +748,26 @@ body {
     overflow-x: hidden;
 }
 
+/* Language switch positioning */
+.language-switch {
+    position: fixed;
+    top: var(--space-16);
+    right: var(--space-16);
+    display: flex;
+    align-items: center;
+    gap: var(--space-8);
+    z-index: 2000;
+}
+
+.language-switch label {
+    font-weight: var(--font-weight-medium);
+}
+
+.language-switch select {
+    cursor: pointer;
+    width: auto;
+}
+
 /* Screen Management */
 .screen {
     position: fixed;

--- a/tests/languageToggle.test.js
+++ b/tests/languageToggle.test.js
@@ -35,4 +35,10 @@ describe('language toggle', () => {
     const appReloaded = require('../app.js');
     expect(appReloaded.getCurrentLanguage()).toBe('ru');
   });
+
+  test('handleLanguageChange alias works', () => {
+    const app = require('../app.js');
+    window.handleLanguageChange('ru');
+    expect(app.getCurrentLanguage()).toBe('ru');
+  });
 });


### PR DESCRIPTION
## Summary
- style the language select widget so it's easy to reach
- keep the dropdown accessible by floating it above screens
- ensure handleLanguageChange alias works

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688a97d78570832e8d17cdf27ab4a2e3